### PR TITLE
Add serverless-offline support

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ class ServerlessS3Local {
 
     this.hooks = {
       's3:start:startHandler': this.startHandler.bind(this),
+      'before:offline:start': this.startHandler.bind(this),
     };
   }
 


### PR DESCRIPTION
Automatically start S3 local when using serverless-offline.
In order for this to work, the serverless-s3-local plugin must be defined before serverless-offline like this:
```yml
plugins:
  - serverless-s3-local
  - serverless-offline
```