### PR TITLE
Update README for offline auto-start

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ serverless.yaml
       name: aws
       runtime: nodejs4.3
     plugins:
-      - serverless-offline
       - serverless-s3-local
+      - serverless-offline
     custom:
       s3:
         port: 8000


### PR DESCRIPTION
Per change 795f999 `serverless-s3-local` needs to be listed before `serverless-offline` under plugins to automatically start.