### PR TITLE
Add option to enable CORS, as supported by s3rver

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ serverless.yaml
         buckets:
           - local-bucket
         directory: /tmp
+        cors: false
     functions:
       webhook:
         handler: handler.webhook

--- a/index.js
+++ b/index.js
@@ -26,7 +26,11 @@ class ServerlessS3Local {
               },
               buckets: {
                 shortcut: 'b',
-                usage: 'After starting S3 local, craete specified buckets',
+                usage: 'After starting S3 local, create specified buckets',
+              },
+              cors: {
+                shortcut: 'c',
+                usage: 'Enable CORS',
               },
             },
           },
@@ -49,8 +53,9 @@ class ServerlessS3Local {
       const port = options.port || 4569;
       const hostname = 'localhost';
       const silent = false;
+      const cors = options.cors || false;
       const directory = options.directory || fs.realpathSync('./');
-      new S3rver({ port, hostname, silent, directory }).run((err, s3Host, s3Port) => {
+      new S3rver({ port, hostname, silent, directory, cors }).run((err, s3Host, s3Port) => {
         if (err) {
           console.error('Error occured while starting S3 local.');
           return;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-local",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Serverless s3 local plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR introduces CORS support to serverless-s3-local, as included in s3rver (implemented [here](https://github.com/jamhall/s3rver/pull/18)).

This is important for our usage of serverless-s3-local as we need to allow clients to PUT straight to s3 buckets (not via serverless lambda functions).