### PR TITLE
Fix offline start support

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,6 +8,7 @@ class ServerlessS3Local {
     this.serverless = serverless;
     this.options = options;
     this.provider = 'aws';
+    this.client = null;
 
     this.commands = {
       s3: {
@@ -41,6 +42,8 @@ class ServerlessS3Local {
     this.hooks = {
       's3:start:startHandler': this.startHandler.bind(this),
       'before:offline:start': this.startHandler.bind(this),
+      'before:offline:start:init': this.startHandler.bind(this),
+      'before:offline:start:end': this.endHandler.bind(this)
     };
   }
 
@@ -55,7 +58,7 @@ class ServerlessS3Local {
       const silent = false;
       const cors = options.cors || false;
       const directory = options.directory || fs.realpathSync('./');
-      new S3rver({ port, hostname, silent, directory, cors }).run((err, s3Host, s3Port) => {
+      this.client = new S3rver({ port, hostname, silent, directory, cors }).run((err, s3Host, s3Port) => {
         if (err) {
           console.error('Error occured while starting S3 local.');
           return;
@@ -74,6 +77,11 @@ class ServerlessS3Local {
 
       resolve();
     });
+  }
+
+  endHandler() {
+    client.close();
+    console.log('S3 local closed');
   }
 }
 


### PR DESCRIPTION
Recently I tried to use this plugin together with serverless offline. As it appeared the only way to get S3 Local started with serverless offline is the use the `sls offline` command. In my case I would like to run `sls offline start` as encouraged by the serverless offline documentation.

serverless: v1.12.1
serverless-offline: v3.15.5

This fix will add the `before:offline:start:init` and `before:offline:start:end` handler without breaking compatibility.

Inspired by @akibe who did this fix in his [fork](https://github.com/akibe/serverless-s3-local/commit/5db85a14bd04b1fd3ccd1556aa794488a65c3fb4). 