### PR TITLE
Adding a noStart option

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -1,1 +1,3 @@
 extends: airbnb-base
+rules:
+  no-console: 0

--- a/README.md
+++ b/README.md
@@ -26,6 +26,8 @@ serverless.yaml
         port: 8000
         directory: /tmp
         cors: false
+        # Uncomment only if you already have a S3 server running locally
+        # noStart: true
     resources:
       Resources:
         NewResource:

--- a/example/handler.js
+++ b/example/handler.js
@@ -1,5 +1,6 @@
 const AWS = require('aws-sdk');
-module.exports.webhook = (event, context, callback) => {
+
+module.exports.webhook = () => {
   const S3 = new AWS.S3({
     s3ForcePathStyle: true,
     endpoint: new AWS.Endpoint('http://localhost:8000'),
@@ -7,6 +8,6 @@ module.exports.webhook = (event, context, callback) => {
   S3.putObject({
     Bucket: 'local-bucket',
     Key: '1234',
-    Body: new Buffer('abcd')
-  }, () => {} );
+    Body: new Buffer('abcd'),
+  }, () => {});
 };

--- a/example/package.json
+++ b/example/package.json
@@ -18,7 +18,7 @@
   "homepage": "https://github.com/ar90n/serverless-s3-local#readme",
   "devDependencies": {
     "serverless-offline": "^3.3.1",
-    "serverless-s3-local": "^0.2.4"
+    "serverless-s3-local": "^0.2.5"
   },
   "dependencies": {
     "aws-sdk": "^2.94.0"

--- a/example/package.json
+++ b/example/package.json
@@ -19,5 +19,8 @@
   "devDependencies": {
     "serverless-offline": "^3.3.1",
     "serverless-s3-local": "^0.2.4"
+  },
+  "dependencies": {
+    "aws-sdk": "^2.94.0"
   }
 }

--- a/index.js
+++ b/index.js
@@ -54,7 +54,7 @@ class ServerlessS3Local {
   }
 
   startHandler() {
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       const config = (this.serverless.service.custom && this.serverless.service.custom.s3) || {};
       const options = Object.assign({}, this.options, config);
 
@@ -66,7 +66,9 @@ class ServerlessS3Local {
       const cors = options.cors || false;
 
       if (options.noStart) {
-        this.createBuckets(port, buckets);
+        ServerlessS3Local.createBuckets(port, buckets);
+        resolve();
+        return;
       }
       const dirPath = options.directory || './buckets';
       fs.ensureDirSync(dirPath); // Create destination directory if not exist
@@ -81,15 +83,15 @@ class ServerlessS3Local {
       }).run((err, s3Host, s3Port) => {
         if (err) {
           console.error('Error occured while starting S3 local.');
+          reject(err);
           return;
         }
 
         console.log(`S3 local started ( port:${s3Port} )`);
 
-        this.createBuckets(s3Port, buckets);
+        ServerlessS3Local.createBuckets(s3Port, buckets);
+        resolve();
       });
-
-      resolve();
     });
   }
 

--- a/index.js
+++ b/index.js
@@ -94,10 +94,7 @@ class ServerlessS3Local {
   }
 
   endHandler() {
-    const config = (this.serverless.service.custom && this.serverless.service.custom.s3) || {};
-    const options = Object.assign({}, this.options, config);
-
-    if (!options.noStart) {
+    if (!this.options.noStart) {
       this.client.close();
       console.log('S3 local closed');
     }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-local",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "Serverless s3 local plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
This PR add a `noStart` option that will disable starting S3 local, but will still create buckets.

Use case: Having a monorepo with multiple serverless services that share the same S3 local instance.