### PR TITLE
Provide callback to lambda function

### DIFF
--- a/index.js
+++ b/index.js
@@ -232,7 +232,7 @@ class ServerlessS3Local {
               const lambdaContext = createLambdaContext(serviceFunction);
               const funOptions = functionHelper.getFunctionOptions(serviceFunction, key, servicePath);
               const handler = functionHelper.createHandler(funOptions, this.options);
-              const eventHandler = (s3Event) => handler(s3Event, lambdaContext)
+              const eventHandler = (s3Event) => handler(s3Event, lambdaContext, lambdaContext.done)
               if(!(name in eventHandlers)) {
                   eventHandlers[name] = {}
               }


### PR DESCRIPTION
Currently the callback parameter is undefined, and so results in an error if it is called.

serverless-offline solves this by providing context.done as the callback function - You can see this in the following block. This PR just emulates that same behavior.

https://github.com/dherault/serverless-offline/blob/4162446f8b8626c40b6bb3dc915a3a0908dbc9ca/src/index.js#L764-L767

