### PR TITLE
Add accessKeyId and secretAccessKey to S3 Client init to remove aws configure dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -10,7 +10,9 @@ const createLambdaContext = require('serverless-offline/src/createLambdaContext'
 const defaultOptions = {
   port: 4569,
   host: 'localhost',
-  location: '.'
+  location: '.',
+  accessKeyId: 'something has to be here',
+  secretAccessKey: 'to prevent requiring ~/.aws/credentials',
 }
 
 class ServerlessS3Local {
@@ -199,7 +201,9 @@ class ServerlessS3Local {
   getClient() {
     return new AWS.S3({
       s3ForcePathStyle: true,
-      endpoint: new AWS.Endpoint(`http://localhost:${this.options.port}`),
+      endpoint: new AWS.Endpoint(`http://${this.options.host}:${this.options.port}`),
+      accessKeyId: this.options.accessKeyId,
+      secretAccessKey: this.options.secretAccessKey,
     });
   }
 


### PR DESCRIPTION
Forgive me if this seems unnecessary, but I noticed that `createBucket` fails if you do not have a local `~/.aws/configuration` file on your machine, even though this fake S3 server doesn't care about access/secret keys. Output will say `Serverless: creating bucket: bucket-name` but it won't actually be created and any errors will be suppressed.

In order to bypass this requirement, we can simply pass in dummy text for `accessKeyId` and `secretAccessKey` when initializing the S3 client.

I also updated the `getClient` method to use the `options.host` value instead of hardcoded localhost.