### PR TITLE
Adding support for projects using local plugins.

### DIFF
--- a/index.js
+++ b/index.js
@@ -364,7 +364,9 @@ class ServerlessS3Local {
     return (
       this.service &&
       this.service.plugins &&
-      this.service.plugins.indexOf('serverless-plugin-additional-stacks') >= 0
+      this.service.plugins.modules
+			? this.service.plugins.modules.indexOf('serverless-plugin-additional-stacks') >= 0
+			: this.service.plugins.indexOf('serverless-plugin-additional-stacks') >= 0
     );
   }
 
@@ -372,7 +374,9 @@ class ServerlessS3Local {
     return (
         this.service &&
         this.service.plugins &&
-        this.service.plugins.indexOf('serverless-plugin-existing-s3') >= 0
+        this.service.plugins.modules
+				? this.service.plugins.modules.indexOf('serverless-plugin-additional-stacks') >= 0
+				: this.service.plugins.indexOf('serverless-plugin-additional-stacks') >= 0
       );
   }
 

--- a/index.js
+++ b/index.js
@@ -375,8 +375,8 @@ class ServerlessS3Local {
         this.service &&
         this.service.plugins &&
         this.service.plugins.modules
-				? this.service.plugins.modules.indexOf('serverless-plugin-additional-stacks') >= 0
-				: this.service.plugins.indexOf('serverless-plugin-additional-stacks') >= 0
+				? this.service.plugins.modules.indexOf('serverless-plugin-existing-s3') >= 0
+				: this.service.plugins.indexOf('serverless-plugin-existing-s3') >= 0
       );
   }
 


### PR DESCRIPTION
Using local plugins changes the structure of the plugin object.
Adding support for this "enhanced" plugin object.

Example below:
```
plugins:
  localPath: './.serverless-plugins'
  modules:
    - slow-down
    - serverless-prune-plugin
    - serverless-s3-local
    - serverless-sentry
    - serverless-plugin-split-stacks
    - serverless-plugin-existing-s3
    - serverless-offline
    - serverless-webpack
```
https://serverless.com/framework/docs/providers/aws/guide/plugins/