### PR TITLE
Removed dangling comma which causes unexpected token error

### DIFF
--- a/index.js
+++ b/index.js
@@ -122,7 +122,7 @@ class ServerlessS3Local {
       'before:offline:start': this.startHandler.bind(this),
       'before:offline:start:end': this.endHandler.bind(this),
       'after:webpack:compile:watch:compile': this.subscriptionWebpackHandler.bind(
-        this,
+        this
       ),
     };
   }
@@ -169,13 +169,13 @@ class ServerlessS3Local {
                 {
                   prefix: !handler.rules.some((rule) => rule.prefix),
                   suffix: !handler.rules.some((rule) => rule.suffix),
-                },
+                }
               );
               return obj.prefix && obj.suffix;
             })
             .map((handler) => () => handler.func(event));
         }),
-        mergeMap((handler) => handler),
+        mergeMap((handler) => handler)
       )
       .subscribe((handler) => {
         handler();
@@ -201,13 +201,13 @@ class ServerlessS3Local {
         cors
           ? fs.readFileSync(
             path.resolve(this.serverless.config.servicePath, cors),
-            'utf8',
+            'utf8'
           )
           : null,
         website
           ? fs.readFileSync(
             path.resolve(this.serverless.config.servicePath, website),
-            'utf8',
+            'utf8'
           )
           : null,
       ].filter((x) => !!x);
@@ -266,7 +266,7 @@ class ServerlessS3Local {
       buckets.map((Bucket) => {
         this.serverless.cli.log(`creating bucket: ${Bucket}`);
         return s3Client.createBucket({ Bucket }).promise();
-      }),
+      })
     ).catch(() => ({}));
   }
 
@@ -280,7 +280,7 @@ class ServerlessS3Local {
         buckets.map((bucket) => {
           this.serverless.cli.log(`removing bucket: ${bucket}`);
           return removeBucket({ port, bucket });
-        }),
+        })
       );
     });
   }
@@ -289,7 +289,7 @@ class ServerlessS3Local {
     return new AWS.S3({
       s3ForcePathStyle: true,
       endpoint: new AWS.Endpoint(
-        `http://${this.options.host}:${this.options.port}`,
+        `http://${this.options.host}:${this.options.port}`
       ),
       accessKeyId: this.options.accessKeyId,
       secretAccessKey: this.options.secretAccessKey,
@@ -306,7 +306,7 @@ class ServerlessS3Local {
 
     if (typeof serviceRuntime !== 'string') {
       throw new Error(
-        'Provider configuration property "runtime" wasn\'t a string.',
+        'Provider configuration property "runtime" wasn\'t a string.'
       );
     }
 
@@ -315,7 +315,7 @@ class ServerlessS3Local {
         serviceRuntime = this.options.providedRuntime;
       } else {
         throw new Error(
-          'Runtime "provided" is unsupported. Please add a --providedRuntime CLI option.',
+          'Runtime "provided" is unsupported. Please add a --providedRuntime CLI option.'
         );
       }
     }
@@ -328,7 +328,7 @@ class ServerlessS3Local {
       )
     ) {
       this.serverless.cli.log(
-        `Warning: found unsupported runtime '${serviceRuntime}'`,
+        `Warning: found unsupported runtime '${serviceRuntime}'`
       );
 
       return null;
@@ -348,7 +348,7 @@ class ServerlessS3Local {
     const eventHandlers = [];
     const servicePath = path.join(
       this.serverless.config.servicePath,
-      this.options.location,
+      this.options.location
     );
     const serviceRuntime = this.getServiceRuntime();
 
@@ -369,7 +369,7 @@ class ServerlessS3Local {
         serviceFunction,
         key,
         servicePath,
-        serviceRuntime,
+        serviceRuntime
       );
 
       const func = (s3Event) => {
@@ -383,12 +383,12 @@ class ServerlessS3Local {
             process.env,
             baseEnvironment,
             this.service.provider.environment,
-            serviceFunction.environment || {},
+            serviceFunction.environment || {}
           );
 
           const handler = functionHelper.createHandler(
             funOptions,
-            this.options,
+            this.options
           );
           const callback = (error, response) => {
             console.log(`serverless-s3-local: callback is called with ${error} and ${response}`)
@@ -416,7 +416,7 @@ class ServerlessS3Local {
             ? existingEvent.replace(/^s3:/, '').replace('*', '.*')
             : '.*';
           eventHandlers.push(
-            ServerlessS3Local.buildEventHandler(s3, name, pattern, s3.rules, func),
+            ServerlessS3Local.buildEventHandler(s3, name, pattern, s3.rules, func)
           );
         });
         this.serverless.cli.log(`Found S3 event listener for ${name}`);
@@ -430,7 +430,7 @@ class ServerlessS3Local {
     const rule2regex = (rule) => Object.keys(rule).map(
       (key) => (key === 'prefix' && { prefix: `^${rule[key]}` }) || {
         suffix: `${rule[key]}$`,
-      },
+      }
     );
     const rules = typeof s3 === 'object'
       ? [].concat(...(s3Rules || []).map(rule2regex))
@@ -538,10 +538,10 @@ class ServerlessS3Local {
             }
 
             return typeof s3 === 'object' ? s3.bucket : s3;
-          }).filter((bucket) => bucket !== null),
+          }).filter((bucket) => bucket !== null)
         );
       },
-      [],
+      []
     );
 
     return Object.keys(resources)

--- a/index.js
+++ b/index.js
@@ -25,7 +25,7 @@ const removeBucket = ({ bucket, port }) => new Promise((resolve, reject) => {
       if (stderr && stderr.indexOf('NoSuchBucket') !== -1) return resolve();
 
       return reject(
-        new Error(`failed to delete bucket ${bucket}: ${stderr || stdout}`),
+        new Error(`failed to delete bucket ${bucket}: ${stderr || stdout}`)
       );
     },
   );


### PR DESCRIPTION
When doing "serverless deploy", an unexpected token ")" error is raised due to the dangling comma at line 28.

Error stack below:
> [Container] 2020/02/06 12:23:47 Running command npm run deploy:dev
> --
> 870 |  
> 871 | > ******************@********* deploy:dev /codebuild/output/src854215207/src
> 872 | > serverless deploy --stage dev --package *************** --force
> 873 |  
> 874 |  
> 875 | Syntax Error -------------------------------------------
> 876 |  
> 877 | /codebuild/output/src854215207/src/node_modules/serverless-s3-local/index.js:29
> 878 | );
> 879 | ^
> 880 | SyntaxError: Unexpected token )
> 881 | at Object.exports.runInThisContext (vm.js:76:16)
> 882 | at Module._compile (module.js:513:28)
> 883 | at Object.Module._extensions..js (module.js:550:10)
> 884 | at Module.load (module.js:458:32)
> 885 | at tryModuleLoad (module.js:417:12)
> 886 | at Function.Module._load (module.js:409:3)
> 887 | at Module.require (module.js:468:17)
> 888 | at require (internal/module.js:20:19)
> 889 | at error (/codebuild/output/src854215207/src/node_modules/serverless/lib/classes/PluginManager.js:26:10)
> 890 | at pluginsObject.modules.filter.map.error (/codebuild/output/src854215207/src/node_modules/serverless/lib/classes/PluginManager.js:127:20)
> 891 | at Array.map (native)
> 892 | at PluginManager.resolveServicePlugins (/codebuild/output/src854215207/src/node_modules/serverless/lib/classes/PluginManager.js:124:8)
> 893 | at PluginManager.loadAllPlugins (/codebuild/output/src854215207/src/node_modules/serverless/lib/classes/PluginManager.js:111:15)
> 894 | at pluginManager.loadConfigFile.then.then (/codebuild/output/src854215207/src/node_modules/serverless/lib/Serverless.js:96:35)
> 895 | at tryCatcher (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/util.js:16:23)
> 896 | at Promise._settlePromiseFromHandler (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:547:31)
> 897 | at Promise._settlePromise (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:604:18)
> 898 | at Promise._settlePromise0 (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:649:10)
> 899 | at Promise._settlePromises (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:729:18)
> 900 | at Promise._fulfill (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:673:18)
> 901 | at Promise._resolveCallback (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:466:57)
> 902 | at Promise._settlePromiseFromHandler (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:559:17)
> 903 | at Promise._settlePromise (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:604:18)
> 904 | at Promise._settlePromise0 (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:649:10)
> 905 | at Promise._settlePromises (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:729:18)
> 906 | at Promise._fulfill (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:673:18)
> 907 | at PromiseArray._resolve (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise_array.js:127:19)
> 908 | at PromiseArray._promiseFulfilled (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise_array.js:145:14)
> 909 | at Promise._settlePromise (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:609:26)
> 910 | at Promise._settlePromise0 (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:649:10)
> 911 | at Promise._settlePromises (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:729:18)
> 912 | at Promise._fulfill (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:673:18)
> 913 | at Promise._resolveCallback (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:466:57)
> 914 | at Promise._settlePromiseFromHandler (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:559:17)
> 915 | at Promise._settlePromise (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:604:18)
> 916 | at Promise._settlePromise0 (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:649:10)
> 917 | at Promise._settlePromises (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:729:18)
> 918 | at Promise._fulfill (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:673:18)
> 919 | at PropertiesPromiseArray.PromiseArray._resolve (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise_array.js:127:19)
> 920 | at PropertiesPromiseArray._promiseFulfilled (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/props.js:78:14)
> 921 | at Promise._settlePromise (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:609:26)
> 922 | at Promise._settlePromise0 (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:649:10)
> 923 | at Promise._settlePromises (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:729:18)
> 924 | at Promise._fulfill (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:673:18)
> 925 | at Promise._resolveCallback (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:466:57)
> 926 | at Promise._settlePromiseFromHandler (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:559:17)
> 927 | at Promise._settlePromise (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:604:18)
> 928 | at Promise._settlePromise0 (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:649:10)
> 929 | at Promise._settlePromises (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/promise.js:725:18)
> 930 | at _drainQueueStep (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/async.js:93:12)
> 931 | at _drainQueue (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/async.js:86:9)
> 932 | at Async._drainQueues (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/async.js:102:5)
> 933 | at Immediate.Async.drainQueues (/codebuild/output/src854215207/src/node_modules/bluebird/js/release/async.js:15:14)
> 934 | at runCallback (timers.js:570:20)
> 935 | at tryOnImmediate (timers.js:550:5)
> 936 | at processImmediate [as _immediateCallback] (timers.js:529:5)
> 937 |  
> 938 | For debugging logs, run again after setting the "SLS_DEBUG=*" environment variable.
> 939 |  
> 940 | Get Support --------------------------------------------
> 941 | Docs:          docs.serverless.com
> 942 | Bugs:          github.com/serverless/serverless/issues
> 943 | Issues:        forum.serverless.com
> 944 |  
> 945 | Your Environment Information ---------------------------
> 946 | Operating System:          linux
> 947 | Node Version:              6.3.1
> 948 | Framework Version:         1.63.0
> 949 | Plugin Version:            3.3.0
> 950 | SDK Version:               2.3.0
> 951 |  
> 952 |  
> 953 | npm ERR! Linux 4.14.152-98.182.amzn1.x86_64
> 954 | npm ERR! argv "/usr/local/bin/node" "/usr/local/bin/npm" "run" "deploy:dev"
> 955 | npm ERR! node v6.3.1
> 956 | npm ERR! npm  v3.10.3
> 957 | npm ERR! code ELIFECYCLE
> 958 | npm ERR! ******************@********* deploy:dev: `serverless deploy --stage dev --package ****************** --force`
> 959 | npm ERR! Exit status 1
> 960 | npm ERR!
> 961 | npm ERR! Failed at the ******************@********* deploy:dev script 'serverless deploy --stage dev --package *************** --force'.
> 962 | npm ERR! Make sure you have the latest version of node.js and npm installed.
> 963 | npm ERR! If you do, this is most likely a problem with the ****************** package,
> 964 | npm ERR! not with npm itself.
> 965 | npm ERR! Tell the author that this fails on your system:
> 966 | npm ERR!     serverless deploy --stage dev --package *************** --force
> 967 | npm ERR! You can get information on how to open an issue for this project with:
> 968 | npm ERR!     npm bugs ******************
> 969 | npm ERR! Or if that isn't available, you can get their info via:
> 970 | npm ERR!     npm owner ls ******************
> 971 | npm ERR! There is likely additional logging output above.
> 972 |  
> 973 | npm ERR! Please include the following file with any support request:
> 974 | npm ERR!     /codebuild/output/src854215207/src/npm-debug.log