### PR TITLE
Add support for reading bucket names  from AWS function results.

### DIFF
--- a/index.js
+++ b/index.js
@@ -210,7 +210,15 @@ class ServerlessS3Local {
           )
           : null,
       ].filter((x) => !!x);
-      const configureBuckets = this.buckets().map((name) => ({ name, configs }));
+      
+      const configureBuckets = this.buckets().map((name) => {
+        if (typeof name === "object") {
+          // Fn::Sub, Fn::Join, Fn::Select
+          const awsFuncKey = Object.keys(name)[0];
+          name = name[awsFuncKey];
+        }
+        return { name, configs };
+      });
 
       this.client = new S3rver({
         address,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "serverless-s3-local",
-  "version": "0.6.3",
+  "version": "0.6.4",
   "description": "Serverless s3 local plugin",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Currently if you use a AWS function in your serverless template (Sub!, Join!, Select!) the template will return an object for the name instead of the name itself which causes S3RVER to throw errors when trying to call Path.Join on the name and directory.
`{ "Fn:Sub": "your-bucket-name"}`
This PR aims to check if the name is an object before instantiating S3RVER. 