### PR TITLE
feat: support starting S3rver with TLS

### DIFF
--- a/index.js
+++ b/index.js
@@ -84,6 +84,11 @@ class ServerlessS3Local {
                 usage:
                   "Override the AWS service root for subdomain-style access",
               },
+              httpsProtocol: {
+                shortcut: "H",
+                usage:
+                    "To enable HTTPS, specify directory (relative to your cwd, typically your project dir) for both cert.pem and key.pem files.",
+              },
             },
           },
           create: {
@@ -199,6 +204,7 @@ class ServerlessS3Local {
         website,
         allowMismatchedSignatures,
         serviceEndpoint,
+        httpsProtocol,
       } = this.options;
       if (noStart) {
         this.createBuckets().then(resolve, reject);
@@ -233,6 +239,12 @@ class ServerlessS3Local {
         return { name, configs };
       });
 
+      let cert;
+      let key;
+      if (typeof httpsProtocol === 'string' && httpsProtocol.length > 0) {
+        cert = fs.readFileSync(path.resolve(httpsProtocol, 'cert.pem'), 'ascii');
+        key = fs.readFileSync(path.resolve(httpsProtocol, 'key.pem'), 'ascii');
+      }
       this.client = new S3rver({
         address,
         port,
@@ -241,6 +253,8 @@ class ServerlessS3Local {
         allowMismatchedSignatures,
         configureBuckets,
         serviceEndpoint,
+        cert,
+        key,
       }).run(
         (err, { port: bindedPort, family, address: bindedAddress } = {}) => {
           if (err) {


### PR DESCRIPTION
Add support for starting S3rver with TLS in a similar manner as done in `serverless-offline`