### PR TITLE
Improve compatibility for serverless-dotenv-plugin

### DIFF
--- a/serverless-s3-local/index.js
+++ b/serverless-s3-local/index.js
@@ -1,6 +1,5 @@
 const S3rver = require('s3rver');
 const fs = require('fs-extra'); // Using fs-extra to ensure destination directory exist
-const AWS = require('aws-sdk');
 const shell = require('shelljs');
 const path = require('path');
 const { fromEvent } = require('rxjs');
@@ -346,6 +345,7 @@ class ServerlessS3Local {
   }
 
   getClient() {
+    const AWS = require('aws-sdk');
     return new AWS.S3({
       s3ForcePathStyle: true,
       endpoint: new AWS.Endpoint(


### PR DESCRIPTION
## Current Issue:

When using serverless-dotenv-plugin to set environment variables for aws credentials:

serverless.yml:
```typeScript
plugins:
  - serverless-dotenv-plugin
  - serverless-offline
  - serverless-s3-local
```

.env:
```
AWS_ACCESS_KEY_ID=S3RVER
AWS_SECRET_ACCESS_KEY=S3RVER
```

The aws-sdk will be initialized when importing  `serverless-s3-local/index.js` at `const AWS = require('aws-sdk');`:
```typeScript
const S3rver = require('s3rver');
const fs = require('fs-extra'); // Using fs-extra to ensure destination directory exist
const AWS = require('aws-sdk');
const shell = require('shelljs');
const path = require('path');
```

But at that time, serverless-dotenv-plugin has not parse `.env` to environment variables due to that it will do that when running plugin constructor:
```typeScript
  constructor(serverless, options) {
    this.serverless = serverless;
    this.serverless.service.provider.environment =
      this.serverless.service.provider.environment || {};

    this.config = Object.assign(
      {
        exclude: [],
        include: '*',
        logging: true,
        required: {},
        variableExpansion: true,
        v4BreakingChanges: false,
      },
      (this.serverless.service.custom &&
        this.serverless.service.custom['dotenv']) ||
        {},
    );

    if (this.config.dotenvParser) {
      this.config.dotenvParserPath = path.join(
        serverless.config.servicePath,
        this.config.dotenvParser,
      );
    }

    this.loadEnv(this.getEnvironment(options));
  }
```

So it will use default profile from user file to init `AWS.config`. Hence the credential in config will be set incorrectly.

## Fix:

Move `const AWS = require('aws-sdk');` to just before usage of `AWS` to make sure the `AWS.config` being initialized after environment variables are set as the plugins loading order defined in `serverless.yml`