### PR TITLE
Issue 449 Update shelljs version to 0.8.5

### DIFF
--- a/serverless-s3-local/package.json
+++ b/serverless-s3-local/package.json
@@ -10,7 +10,7 @@
         "rxjs-compat": "^6.6.7",
         "s3rver": "^3.7.0",
         "serverless-offline": "^8.0.0",
-        "shelljs": "^0.8.4"
+        "shelljs": "^0.8.5"
     },
     "devDependencies": {
         "in-publish": "2.0.1"


### PR DESCRIPTION
The dependency shelljs has a HIGH vulnerability in version 0.8.4 that is resolved in 0.8.5
This is detailed in this snyk report
See also (CVE-2022-0144)[https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-0144]

This change just updates the version in the package file.