### PR TITLE
Migrate to serverless-offline 11.x

### DIFF
--- a/serverless-s3-local/index.js
+++ b/serverless-s3-local/index.js
@@ -417,7 +417,7 @@ class ServerlessS3Local {
 
     this.service.getAllFunctions().forEach((functionKey) => {
       const functionDefinition = this.service.getFunction(functionKey);
-      lambda._create({functionKey, functionDefinition}); // eslint-disable-line no-underscore-dangle
+      lambda.create([{functionKey, functionDefinition}]); // eslint-disable-line no-underscore-dangle
 
       const func = (s3Event) => {
         const baseEnvironment = {

--- a/serverless-s3-local/index.js
+++ b/serverless-s3-local/index.js
@@ -4,7 +4,6 @@ const shell = require("shelljs");
 const path = require("path");
 const { fromEvent } = require("rxjs");
 const { map, mergeMap } = require("rxjs/operators");
-const { default: Lambda } = require("serverless-offline/dist/lambda/");
 
 const defaultOptions = {
   port: 4569,
@@ -37,6 +36,8 @@ class ServerlessS3Local {
     this.options = options;
     this.provider = "aws";
     this.client = null;
+    this.lambdaHandler = null;
+
 
     this.commands = {
       s3: {
@@ -266,35 +267,39 @@ class ServerlessS3Local {
         );
         key = fs.readFileSync(path.resolve(httpsProtocol, "key.pem"), "ascii");
       }
-      this.client = new S3rver({
-        address,
-        port,
-        silent: this.options.silent,
-        directory,
-        allowMismatchedSignatures,
-        configureBuckets,
-        serviceEndpoint,
-        cert,
-        key,
-        vhostBuckets,
-      }).run(
-        (err, { port: bindedPort, family, address: bindedAddress } = {}) => {
-          if (err) {
-            this.serverless.cli.log("Error occurred while starting S3 local.");
-            reject(err);
-            return;
+
+      import('serverless-offline/lambda').then(module => {
+        this.lambdaHandler = module.default;
+        this.client = new S3rver({
+          address,
+          port,
+          silent: this.options.silent,
+          directory,
+          allowMismatchedSignatures,
+          configureBuckets,
+          serviceEndpoint,
+          cert,
+          key,
+          vhostBuckets,
+        }).run(
+          (err, { port: bindedPort, family, address: bindedAddress } = {}) => {
+            if (err) {
+              this.serverless.cli.log("Error occurred while starting S3 local.");
+              reject(err);
+              return;
+            }
+
+            this.options.port = bindedPort;
+            this.serverless.cli.log(
+              `S3 local started ( port:${bindedPort}, family: ${family}, address: ${bindedAddress} )`
+            );
+
+            resolve();
           }
-
-          this.options.port = bindedPort;
-          this.serverless.cli.log(
-            `S3 local started ( port:${bindedPort}, family: ${family}, address: ${bindedAddress} )`
-          );
-
-          resolve();
-        }
-      );
-      this.serverless.cli.log("starting handler");
-      this.subscribe();
+        );
+        this.serverless.cli.log("starting handler");
+        this.subscribe();
+      });
     });
   }
 
@@ -407,12 +412,12 @@ class ServerlessS3Local {
       return {};
     }
 
-    const lambda = new Lambda(this.serverless, this.options);
+    const lambda = new this.lambdaHandler(this.serverless, this.options);
     const eventHandlers = [];
 
     this.service.getAllFunctions().forEach((functionKey) => {
       const functionDefinition = this.service.getFunction(functionKey);
-      lambda._create(functionKey, functionDefinition); // eslint-disable-line no-underscore-dangle
+      lambda._create({functionKey, functionDefinition}); // eslint-disable-line no-underscore-dangle
 
       const func = (s3Event) => {
         const baseEnvironment = {

--- a/serverless-s3-local/package.json
+++ b/serverless-s3-local/package.json
@@ -9,7 +9,7 @@
         "rxjs": "^6.6.7",
         "rxjs-compat": "^6.6.7",
         "s3rver": "^3.7.0",
-        "serverless-offline": "^8.0.0",
+        "serverless-offline": "^11.6.0",
         "shelljs": "^0.8.5"
     },
     "devDependencies": {


### PR DESCRIPTION
Hello,

i created a small patch and updated your fabulous plugin to a more recent serverless-offline version. The reason is, that nodejs18x was not support in your published version. My code contribution is not the best and only migrate your code in a more unconventional way to the latest version. Your code would need a refactoring to support the new import and async / await. Nevertheless, for me it works so far and it would be nice if you can release a newer official version. 

Inspiration for a refactoring of your code can be found at the other [s3 offline plugin](https://github.com/CoorpAcademy/serverless-plugins/blob/master/packages/serverless-offline-s3/src/index.js). But your plugin suits my use-cases more, since no additional docker container is needed. 


If everyone wants to use my version until a newer official version is published:
1) remove `node_modules/serverless-s3-local`
2) change you `package.json` dependencies to `"serverless-s3-local-project": "github:a-marcel/serverless-s3-local"`
3) add a script `postinstall`to your `package.json`: `"postinstall": "npm install -O s3rver shelljs && ln -snf 'serverless-s3-local-project/serverless-s3-local' node_modules/serverless-s3-local"`
4) run `npm upddate`
5) run `npm run postinstall` (you need to run this after every installation/update of any node module


*Hint*
I'm pretty sure that this works for serverless-offline 12.x too but some of my other offline plugins are not ready for this version yet. 

