### PR TITLE
Take Bucket Ref into account

### DIFF
--- a/serverless-s3-local/index.js
+++ b/serverless-s3-local/index.js
@@ -505,9 +505,11 @@ class ServerlessS3Local {
   }
 
   getResourceForBucket(bucketName) {
-    const logicalResourceName = `S3Bucket${bucketName
-      .charAt(0)
-      .toUpperCase()}${bucketName.substr(1)}`;
+    const logicalResourceName = bucketName.Ref
+      ? bucketName.Ref
+      : `S3Bucket${bucketName
+          .charAt(0)
+          .toUpperCase()}${bucketName.substr(1)}`;
     return this.service.resources && this.service.resources.Resources
       ? this.service.resources.Resources[logicalResourceName]
       : false;


### PR DESCRIPTION
In our project we specify buckets via Ref:

```yaml
events:
  - s3:
      existing: true
      bucket: !Ref IndexBucket
      rules:
        - prefix: data/batch/
```

unfortunately it breaks `getResourceForBucket` function

current PR fixes that issue